### PR TITLE
drawing-layer 에서 터치 포인트에 변화가 없었다면 스냅샷으로 기록하지 않도록 수정합니다.

### DIFF
--- a/client/src/components/molecules/canvas/canvas-drawing-layer.ts
+++ b/client/src/components/molecules/canvas/canvas-drawing-layer.ts
@@ -162,6 +162,11 @@ export default class VCanvasDrawingLayer extends HTMLElement {
     }
 
     const takeCanvasSnapshot = () => {
+      const hasPencilPoints = this.points.length > 0
+      if (!hasPencilPoints) {
+        return
+      }
+
       const snapshot = takeSnapshot(this.$canvas)
       if (snapshot) {
         CanvasContext.dispatch({ action: 'PUSH_SNAPSHOT', data: [snapshot] })


### PR DESCRIPTION
## 🔍 What is this PR?

관련 이슈: #25 

## 📝 Changes

- 스냅샷 저장하기 전에 points 배열에 저장된 터치 포인트가 있는지 확인하도록 변경